### PR TITLE
Perbaiki unggahan file bukti untuk auditee

### DIFF
--- a/resources/views/livewire/standar-mutu/index.blade.php
+++ b/resources/views/livewire/standar-mutu/index.blade.php
@@ -57,7 +57,7 @@
                             <div class="row g-3 mb-4">
                                 
                                 <!-- Tahun Field -->
-                                @if($canFullAccess)
+                                @if($canFullAccess || ($canUploadAndCommentAuditee && !$isEditMode))
                                 <div class="col-md-6">
                                     <div class="mb-3">
                                         <label for="tahun_id" class="form-label fw-medium">{{ __('Tahun') }} <span class="text-danger">*</span></label>
@@ -90,7 +90,7 @@
                                 @endif
 
                                 <!-- Lembaga Akreditasi Field -->
-                                @if($canFullAccess)
+                                @if($canFullAccess || ($canUploadAndCommentAuditee && !$isEditMode))
                                 <div class="col-md-6">
                                     <div class="mb-3">
                                         <label for="lembaga_akreditasi_id" class="form-label fw-medium">{{ __('Lembaga Akreditasi') }} <span class="text-danger">*</span></label>
@@ -123,7 +123,7 @@
                                 @endif
 
                                 <!-- Standar Nasional Field -->
-                                @if($canFullAccess)
+                                @if($canFullAccess || ($canUploadAndCommentAuditee && !$isEditMode))
                                 <div class="col-12">
                                     <div class="mb-3">
                                         <label for="standar_nasional_id" class="form-label fw-medium">{{ __('Standar Nasional') }} <span class="text-danger">*</span></label>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable auditee users to upload document files when creating new Standar Mutu records.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, auditee users could only upload files when editing existing records. This PR extends the functionality to allow file uploads during new record creation, including necessary adjustments to validation rules, backend logic for saving new records, and frontend visibility of required fields. It also ensures the file input is properly reset after form submission.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1bcbd0c-71cc-42e2-8d5d-cc967ecef105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1bcbd0c-71cc-42e2-8d5d-cc967ecef105">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>